### PR TITLE
2.1 had "Inclde" typo, fix for Thursday lab

### DIFF
--- a/labs/lab-03/readme.md
+++ b/labs/lab-03/readme.md
@@ -182,7 +182,7 @@ With the introduction of branching we are also introducing your first opportunit
 
 :white_check_mark: Question 8.
 ```c++
-#inclde <iostream>
+#include <iostream>
 int main() {
     int test = 0;
 
@@ -198,7 +198,7 @@ int main() {
 
 :white_check_mark: Question 9.
 ```c++
-#inclde <iostream>
+#include <iostream>
 int main() {
     int test = 0;
 
@@ -214,7 +214,7 @@ int main() {
 
 :white_check_mark: Question 10.
 ```c++
-#inclde <iostream>
+#include <iostream>
 int main() {
     int test = 0;
 


### PR DESCRIPTION
Since it wasn't meant to be the actual error, I suggest it is fixed for future labs.